### PR TITLE
Add 'chef-client --why-run' support.

### DIFF
--- a/resources/destination.rb
+++ b/resources/destination.rb
@@ -59,3 +59,10 @@ action :delete do
     notifies :restart, 'service[syslog-ng]', :delayed
   end
 end
+
+# https://github.com/chef/chef/issues/4537
+action_class do
+  def whyrun_supported?
+    true
+  end
+end

--- a/resources/file.rb
+++ b/resources/file.rb
@@ -69,3 +69,10 @@ action :delete do
     action :delete
   end
 end
+
+# https://github.com/chef/chef/issues/4537
+action_class do
+  def whyrun_supported?
+    true
+  end
+end

--- a/resources/filter.rb
+++ b/resources/filter.rb
@@ -43,3 +43,10 @@ action :delete do
     notifies :restart, 'service[syslog-ng]', :delayed
   end
 end
+
+# https://github.com/chef/chef/issues/4537
+action_class do
+  def whyrun_supported?
+    true
+  end
+end

--- a/resources/forwarder.rb
+++ b/resources/forwarder.rb
@@ -39,3 +39,10 @@ action :delete do
     action :delete
   end
 end
+
+# https://github.com/chef/chef/issues/4537
+action_class do
+  def whyrun_supported?
+    true
+  end
+end

--- a/resources/logpath.rb
+++ b/resources/logpath.rb
@@ -54,3 +54,10 @@ action :delete do
     notifies :restart, 'service[syslog-ng]', :delayed
   end
 end
+
+# https://github.com/chef/chef/issues/4537
+action_class do
+  def whyrun_supported?
+    true
+  end
+end

--- a/resources/source.rb
+++ b/resources/source.rb
@@ -62,3 +62,10 @@ action :delete do
     notifies :restart, 'service[syslog-ng]', :delayed
   end
 end
+
+# https://github.com/chef/chef/issues/4537
+action_class do
+  def whyrun_supported?
+    true
+  end
+end


### PR DESCRIPTION
None of the resources do anything besides create resources that all have `--why-run` support.  So, mark them as supporting it using the published workaround for chef > 12.9.41.